### PR TITLE
Fix Author Metadata

### DIFF
--- a/_posts/2024-06-13-contrast-learning.md
+++ b/_posts/2024-06-13-contrast-learning.md
@@ -12,6 +12,10 @@ authors:
     url: "https://patrickfeeney.github.io/"
     affiliations:
       name: Tufts University
+  - name: Michael C. Hughes
+    url: "https://www.michaelchughes.com/"
+    affiliations:
+      name: Tufts University
 
 bibliography: 2024-06-13-contrast-learning.bib
 ---


### PR DESCRIPTION
An author was erroneously left out of the post metadata. This pull request only fixes that issue.